### PR TITLE
Made inline delimiter length customizable

### DIFF
--- a/test/options.js
+++ b/test/options.js
@@ -13,6 +13,24 @@ describe("Options", function() {
     var res2 = md.render("$$$\n40,2\n$$$");
     assert.equal(res2, '<math display="block">\n<mn>40,2</mn></math>\n');
   });
+
+  it('Should allow customization of inline delimiter length', function() {
+    var md = require('markdown-it')()
+          .use(require('../'), {requiredInlineDelimsCount: 1});
+
+    var res1 = md.render("$x$");
+    assert.equal(res1, '<p><math><mi>x</mi></math></p>\n');
+
+    md = require('markdown-it')()
+          .use(require('../'), {requiredInlineDelimsCount: 5});
+
+    var res2 = md.render("$$$$$x$$$$$");
+    assert.equal(res2, '<p><math><mi>x</mi></math></p>\n');
+
+    // And should not render a shorter delimiter
+    var res3 = md.render("$$$$x$$$$");
+    assert.equal(res3, '<p>$$$$x$$$$</p>\n');
+  });
 });
 
 describe("Renderer", function() {


### PR DESCRIPTION
I want to be able to use your plugin in [Markdown Here](https://github.com/adam-p/markdown-here) when I switch the renderer to markdown-it, but MDH's math support uses `$` rather than `$$` as the inline delimiter. So... this PR makes the inline delimiter length customizable.

I would prefer to use your plugin rather than maintain a fork with this one change, but I understand if you don't want to merge this -- it's not very exciting and doesn't do much for you. 
