### PR TITLE
Lazy Load ascii2mathml

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var ascii2mathml = require('ascii2mathml');
+var ascii2mathml = null;
 require('./lib/polyfills');
 
 
@@ -214,6 +214,9 @@ function makeMath_block(open, close) {
 }
 
 function makeMathRenderer(options) {
+  if (ascii2mathml === null) {
+    ascii2mathml = require('ascii2mathml');
+  }
   var mathml = ascii2mathml(Object.assign({}, options));
 
   return options && options.display === 'block' ?


### PR DESCRIPTION
As already mentioned, ascii2mathml breaks the atom editor, as it has some polyfills. (https://github.com/runarberg/ascii2mathml/issues/6)

The quickest solution for us would be to lazyload ascii2mathml which also would be a good Idea in general, if you want to support independent math parsers. If it is not needed, it is not loaded.

See also issue: https://github.com/Galadirith/markdown-preview-plus/issues/86
