### PR TITLE
Optionally pass token directly to renderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,12 +235,12 @@ module.exports = function math_plugin(md, options) {
       blockClose = options.blockClose || '$$$';
   var inlineRenderer = options.inlineRenderer ?
         function(tokens, idx) {
-          return options.inlineRenderer(tokens[idx].content);
+          return options.inlineRenderer(tokens[idx].content, tokens[idx]);
         } :
       makeMathRenderer(options.renderingOptions);
   var blockRenderer = options.blockRenderer ?
         function(tokens, idx) {
-          return options.blockRenderer(tokens[idx].content) + '\n';
+          return options.blockRenderer(tokens[idx].content, tokens[idx]) + '\n';
         } :
       makeMathRenderer(Object.assign({ display: 'block' },
                                      options.renderingOptions));


### PR DESCRIPTION
This simple patch passes token itself to custom renderer function as a second parameter.

This is useful to handle `token.attrs` or whatever else in custom renderer, if some other plugin changes those.

This doesn't change existing API, only extends it.

Let me know if you want me to add a minimal testcase.