### PR TITLE
Accept multitple delimiter pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ npm install mathup --save
 
 ### In a browser
 
-Use an [importmap][importmap]. Change `/path/to/modules` to the location of your modules.
+Use an [importmap][importmap]. Change `/path/to/modules` to the
+location of your modules.
 
 ```html
 <!--mathup is optional -->
@@ -107,10 +108,8 @@ import markdownItMath from "markdown-it-math";
 
 // Optional (with defaults)
 const options = {
-  inlineOpen: "$",
-  inlineClose: "$",
-  blockOpen: "$$",
-  blockClose: "$$",
+  inlineDelimiters: ["$", ["$`", "`$"]]
+  blockDelimiters: "$$",
   defaultRendererOptions,
   inlineCustomElement, // see below
   inlineRenderer, // see below
@@ -137,12 +136,16 @@ $$
 
 ### Options
 
-- `inlineOpen`: The delimiter to start an inline math expression. Default `$`
-- `inlineClose`: The delimiter to close an inline math expression. Default `$`
-- `blockOpen`: The delimiter to start a block math expression. Default `$$`
-- `blockClose`: The delimiter to close a block math expression. Default `$$`
-- `defaultRendererOptions`:
-  The options passed into the default renderer. Ignored if you use a custom renderer. Default `{}`
+- `inlineDelimiters`: A string, or an array of strings (or pairs of
+  strings) specifying delimiters for inline math expressions. If a
+  string, the same delimiter is used for open and close. If a pair of
+  strings, the first string opens and the second one closes. Empty
+  strings or pairs containing empty strings are ignored. If no valid
+  strings or pairs are provided, it will turn off the rule.
+  Default ``["$", ["$`", "`$"]]``.
+- `blockDelimiters`: Same as above, but for block expressions. Default `"$$"`.
+- `defaultRendererOptions`: The options passed into the default
+  renderer. Ignored if you use a custom renderer. Default `{}`
 - `inlineCustomElement`:
   Specify `"tag-name"` or `["tag-name", { some: "attrs" }]` if you want to
   render inline expressions to a custom element. Ignored if you provide a
@@ -226,6 +229,27 @@ md.render("$\\sin(2\\pi)$");
 // <p><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo lspace="0em" rspace="0em">sin</mo><mo stretchy="false">(</mo><mn>2</mn><mi>π</mi><mo stretchy="false">)</mo></mrow><annotation encoding="TeX">\sin(2\pi)</annotation></semantics></math></p>
 ```
 
+Turning off inline math:
+
+```js
+import markdownIt from "markdown-it";
+import markdownItMath from "markdown-it-math";
+
+const md = markdownIt().use(markdownItMath, {
+  inlineDelimiters: "",
+});
+```
+
+```md
+Only block math is allowed. $a^2$ will not render into inline math.
+
+But this will render into block math:
+
+$$
+a^2
+$$
+```
+
 Using LaTeX style delimiters:
 
 ```js
@@ -233,27 +257,24 @@ import markdownIt from "markdown-it";
 import markdownItMath from "markdown-it-math";
 
 const md = markdownIt().use(markdownItMath, {
-  inlineOpen: "\\(",
-  inlineClose: "\\)",
-  blockOpen: "\\[",
-  blockClose: "\\]",
+  inlineDelimiters: [["\\(", "\\)"]],
+  blockDelimiters: [["\\[", "\\]"]],
 });
 ```
 
 Note there are restrictions on what inline delimiters you can use,
 based on optimization for the markdown-it parser [see here for
-details][why-my-inline-rule-is-not-executed]. And block level math
-must be on its own lines with newlines separating the math from the
-delimiters.
+details][why-my-inline-rule-is-not-executed].
+
+Block level math must be on its own lines.
 
 ```markdown
 Some text with inline math \(a^2 + b^2 = c^2\)
 
-And block math
+And block math:
+\[e = sum\_(n=0)^oo 1/n!\]
 
-\[
-e = sum\_(n=0)^oo 1/n!
-\]
+This expression \[P(x \in X) = 0\] will not render.
 ```
 
 [importmap]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
@@ -270,15 +291,26 @@ e = sum\_(n=0)^oo 1/n!
 
 Version 5 introduced some breaking changes, along with dropping legacy platforms.
 
+- The `inlineOpen`, `inlineClose`, `blockOpen`, and `blockClose` options have
+  been depricated in favor of `inlineDelimiters` and `blockDelimiters`
+  respectively.
+  ```diff
+    markdownIt().use(markdownItMath, {
+  -   inlineOpen: "$",
+  -   inlineClose: "$",
+  -   blockOpen: "$$",
+  -   blockClose: "$$",
+  +   inlineDelimiters: "$",
+  +   blockDelimiters: "$$",
+    });
+  ```
 - The default delimiters changed from `$$` and `$$$` for inline and
   block math respectively to `$` and `$$`. If you want to keep the
   thicker variants, you must set the relevant options:
   ```js
   markdownIt().use(markdownItMath, {
-    inlineOpen: "$$",
-    inlineClose: "$$",
-    blockOpen: "$$$",
-    blockClose: "$$$",
+    inlineDelimiters: "$$",
+    blockDelimiters: "$$$",
   });
   ```
 - The options passed into the default mathup renderer has been renamed

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
  * @typedef {import("markdown-it/lib/rules_block/state_block.mjs").default} StateBlock
  * @typedef {import("markdown-it/lib/rules_inline/state_inline.mjs").default} StateInline
  * @typedef {import("markdown-it/lib/token.mjs").default} Token
+ * @typedef {string | [string, string]} Delimiter
  */
 
 /** @type {import("mathup").default | undefined} */
@@ -17,203 +18,203 @@ try {
 }
 
 /**
- * @param {StateInline} state
- * @param {number} start
- * @param {number} delimLength
- * @returns {{ can_open: boolean; can_close: boolean; delims: number }}
+ * @param {string | Delimiter[]} delimiters
+ * @returns {Array<[string, string]> | null}
  */
-function scanDelims(state, start, delimLength) {
-  let pos = start;
-  const max = state.posMax;
+function fromDelimiterOption(delimiters) {
+  if (typeof delimiters === "string") {
+    if (delimiters.length === 0) {
+      return null;
+    }
 
-  // treat beginning of the line as a whitespace
-  const lastChar = start > 0 ? state.src.charCodeAt(start - 1) : 0x20;
+    return [[delimiters, delimiters]];
+  }
 
-  pos += delimLength;
+  /** @type {Array<[string, string]>} */
+  const pairs = [];
+  for (const pair of delimiters) {
+    if (typeof pair === "string") {
+      if (pair.length === 0) {
+        continue;
+      }
 
-  const count = pos - start;
+      pairs.push([pair, pair]);
+    } else {
+      if (pair[0].length === 0 || pair[1].length === 0) {
+        continue;
+      }
 
-  // treat end of the line as a whitespace
-  const nextChar = pos < max ? state.src.charCodeAt(pos) : 0x20;
+      pairs.push(pair);
+    }
+  }
 
-  const left_flanking = !state.md.utils.isWhiteSpace(nextChar);
-  const right_flanking = !state.md.utils.isWhiteSpace(lastChar);
+  if (pairs.length === 0) {
+    return null;
+  }
 
-  return {
-    can_open: left_flanking,
-    can_close: right_flanking,
-    delims: count,
-  };
+  // Make sure we match longer variants first.
+  return pairs.sort(([a], [b]) => b.length - a.length);
 }
 
 /**
- * @param {string} open
- * @param {string} close
+ * @param {Array<[string, string]>} delimiters
  * @returns {RuleInline}
  */
-function createInlineMathRule(open, close) {
-  return function math_inline(state, silent) {
-    const max = state.posMax;
+function createInlineMathRule(delimiters) {
+  return (state, silent) => {
     const start = state.pos;
-    const openDelim = state.src.slice(start, start + open.length);
 
-    if (openDelim !== open) {
+    const markers = delimiters.filter(
+      ([open]) => open === state.src.slice(start, start + open.length),
+    );
+
+    if (markers.length === 0) {
       return false;
     }
-    if (silent) {
-      return false;
-    } // Don’t run any pairs in validation mode
 
-    let res = scanDelims(state, start, openDelim.length);
-    const startCount = res.delims;
+    // Scan until the end of the line (or until close marker is found).
+    for (const [open, close] of markers) {
+      const pos = start + open.length;
 
-    if (!res.can_open) {
-      state.pos += startCount;
-      // Earlier we checked !silent, but this implementation does not need it
-      state.pending += state.src.slice(start, state.pos);
+      if (state.md.utils.isWhiteSpace(state.src.charCodeAt(pos))) {
+        // Don’t allow whitespace immediately after open delimiter ... for now.
+        continue;
+      }
+
+      const matchStart = state.src.indexOf(close, pos);
+
+      if (matchStart === -1 || pos === matchStart) {
+        // Don’t allow empty expressions.
+        continue;
+      }
+
+      // Don’t allow whitespace immediately before close delimiter ... for now.
+      if (state.md.utils.isWhiteSpace(state.src.charCodeAt(matchStart - 1))) {
+        continue;
+      }
+
+      const content = state.src.slice(pos, matchStart);
+
+      if (!silent) {
+        const token = state.push("math_inline", "math", 0);
+
+        token.markup = open;
+        token.content = content;
+      }
+
+      state.pos = matchStart + close.length;
+
       return true;
     }
 
-    state.pos = start + open.length;
-
-    /** @type {string | undefined} */
-    let closeDelim;
-    let found = false;
-
-    while (state.pos < max) {
-      closeDelim = state.src.slice(state.pos, state.pos + close.length);
-      if (closeDelim === close) {
-        res = scanDelims(state, state.pos, close.length);
-        if (res.can_close) {
-          found = true;
-          break;
-        }
-      }
-
-      state.md.inline.skipToken(state);
-    }
-
-    if (!found) {
-      // Parser failed to find ending tag, so it is not a valid math
-      state.pos = start;
-      return false;
-    }
-
-    // Found!
-    state.posMax = state.pos;
-    state.pos = start + close.length;
-
-    // Earlier we checked !silent, but this implementation does not need it
-    const token = state.push("math_inline", "math", 0);
-    token.content = state.src.slice(state.pos, state.posMax);
-    token.markup = open;
-
-    state.pos = state.posMax + close.length;
-    state.posMax = max;
-
-    return true;
+    return false;
   };
 }
 
 /**
- * @param {string} open
- * @param {string} close
+ * @param {Array<[string, string]>} delimiters
  * @returns {RuleBlock}
  */
-function createBlockMathRule(open, close) {
+function createBlockMathRule(delimiters) {
   return function math_block(state, startLine, endLine, silent) {
-    let pos = state.bMarks[startLine] + state.tShift[startLine];
-    let max = state.eMarks[startLine];
+    const start = state.bMarks[startLine] + state.tShift[startLine];
 
-    if (pos + open.length > max) {
-      return false;
-    }
+    for (const [open, close] of delimiters) {
+      let pos = start;
+      let max = state.eMarks[startLine];
 
-    const openDelim = state.src.slice(pos, pos + open.length);
+      if (pos + open.length > max) {
+        continue;
+      }
 
-    if (openDelim !== open) {
-      return false;
-    }
+      const openDelim = state.src.slice(pos, pos + open.length);
 
-    pos += open.length;
-    let firstLine = state.src.slice(pos, max);
+      if (openDelim !== open) {
+        continue;
+      }
 
-    // Since start is found, we can report success here in validation mode
-    if (silent) {
+      pos += open.length;
+      let firstLine = state.src.slice(pos, max);
+
+      // Since start is found, we can report success here in validation mode
+      if (silent) {
+        return true;
+      }
+
+      let haveEndMarker = false;
+
+      if (firstLine.trim().slice(-close.length) === close) {
+        // Single line expression
+        firstLine = firstLine.trim().slice(0, -close.length);
+        haveEndMarker = true;
+      }
+
+      // search end of block
+      let nextLine = startLine;
+      /** @type {string | undefined} */
+      let lastLine;
+
+      for (;;) {
+        if (haveEndMarker) {
+          break;
+        }
+
+        nextLine += 1;
+
+        if (nextLine >= endLine) {
+          // unclosed block should be autoclosed by end of document.
+          // also block seems to be autoclosed by end of parent
+          break;
+        }
+
+        pos = state.bMarks[nextLine] + state.tShift[nextLine];
+        max = state.eMarks[nextLine];
+
+        if (state.src.slice(pos, max).trim().slice(-close.length) !== close) {
+          continue;
+        }
+
+        if (state.tShift[nextLine] - state.blkIndent >= 4) {
+          // closing block math should be indented less then 4 spaces
+          continue;
+        }
+
+        const lastLinePos = state.src.slice(0, max).lastIndexOf(close);
+        lastLine = state.src.slice(pos, lastLinePos);
+
+        pos += lastLine.length + close.length;
+
+        // make sure tail has spaces only
+        pos = state.skipSpaces(pos);
+
+        if (pos < max) {
+          continue;
+        }
+
+        // found!
+        haveEndMarker = true;
+      }
+
+      // If math block has heading spaces, they should be removed from its inner block
+      const len = state.tShift[startLine];
+
+      state.line = nextLine + (haveEndMarker ? 1 : 0);
+
+      const token = state.push("math_block", "math", 0);
+      token.block = true;
+
+      const firstLineContent = firstLine && firstLine.trim() ? firstLine : "";
+      const contentLines = state.getLines(startLine + 1, nextLine, len, false);
+      const lastLineContent = lastLine && lastLine.trim() ? lastLine : "";
+
+      token.content = `${firstLineContent}${firstLineContent && (contentLines || lastLineContent) ? "\n" : ""}${contentLines}${contentLines && lastLineContent ? "\n" : ""}${lastLineContent}`;
+      token.map = [startLine, state.line];
+      token.markup = open;
+
       return true;
     }
 
-    let haveEndMarker = false;
-
-    if (firstLine.trim().slice(-close.length) === close) {
-      // Single line expression
-      firstLine = firstLine.trim().slice(0, -close.length);
-      haveEndMarker = true;
-    }
-
-    // search end of block
-    let nextLine = startLine;
-    /** @type {string | undefined} */
-    let lastLine;
-
-    for (;;) {
-      if (haveEndMarker) {
-        break;
-      }
-
-      nextLine += 1;
-
-      if (nextLine >= endLine) {
-        // unclosed block should be autoclosed by end of document.
-        // also block seems to be autoclosed by end of parent
-        break;
-      }
-
-      pos = state.bMarks[nextLine] + state.tShift[nextLine];
-      max = state.eMarks[nextLine];
-
-      if (state.src.slice(pos, max).trim().slice(-close.length) !== close) {
-        continue;
-      }
-
-      if (state.tShift[nextLine] - state.blkIndent >= 4) {
-        // closing block math should be indented less then 4 spaces
-        continue;
-      }
-
-      const lastLinePos = state.src.slice(0, max).lastIndexOf(close);
-      lastLine = state.src.slice(pos, lastLinePos);
-
-      pos += lastLine.length + close.length;
-
-      // make sure tail has spaces only
-      pos = state.skipSpaces(pos);
-
-      if (pos < max) {
-        continue;
-      }
-
-      // found!
-      haveEndMarker = true;
-    }
-
-    // If math block has heading spaces, they should be removed from its inner block
-    const len = state.tShift[startLine];
-
-    state.line = nextLine + (haveEndMarker ? 1 : 0);
-
-    const token = state.push("math_block", "math", 0);
-    token.block = true;
-
-    const firstLineContent = firstLine && firstLine.trim() ? firstLine : "";
-    const contentLines = state.getLines(startLine + 1, nextLine, len, false);
-    const lastLineContent = lastLine && lastLine.trim() ? lastLine : "";
-
-    token.content = `${firstLineContent}${firstLineContent && (contentLines || lastLineContent) ? "\n" : ""}${contentLines}${contentLines && lastLineContent ? "\n" : ""}${lastLineContent}`;
-    token.map = [startLine, state.line];
-    token.markup = open;
-
-    return true;
+    return false;
   };
 }
 
@@ -275,26 +276,36 @@ function defaultBlockRenderer(options, md) {
  * @param {Token} token - The parsed markdown-it token
  * @param {MarkdownIt} md - The markdown-it instance
  * @typedef {object} PluginOptions
- * @property {string} [inlineOpen] - Inline math open delimiter.
- * @property {string} [inlineClose] - Inline math close delimeter.
+ * @property {string | Delimiter[]} [inlineDelimiters] - Inline math delimiters.
+ * @property {string} [inlineOpen] - Deprecated: Use inlineDelimiters
+ * @property {string} [inlineClose] - Deprecated: Use inlineDelimiters
  * @property {CustomElementOption} [inlineCustomElement] - If you want to render to a custom element.
- * @property {MathupOptions} [defaultRendererOptions] - The options passed into the default renderer.
  * @property {Renderer} [inlineRenderer] - Custom renderer for inline math. Default mathup.
- * @property {string} [blockOpen] - Block math open delimter.
- * @property {string} [blockClose] - Block math close delimter.
+ * @property {string | Delimiter[]} [blockDelimiters] - Block math delimters.
+ * @property {string} [blockOpen] - Deprecated: Use blockDelimiters
+ * @property {string} [blockClose] - Deprecated: Use blockDelimiters
  * @property {CustomElementOption} [blockCustomElement] - If you want to render to a custom element.
  * @property {Renderer} [blockRenderer] - Custom renderer for block math. Default mathup with display = "block".
+ * @property {MathupOptions} [defaultRendererOptions] - The options passed into the default renderer.
  */
 
 /** @type {import("markdown-it").PluginWithOptions<PluginOptions>} */
 export default function markdownItMath(
   md,
   {
-    inlineOpen = "$",
-    inlineClose = "$",
-    blockOpen = "$$",
-    blockClose = "$$",
     defaultRendererOptions = {},
+
+    inlineOpen,
+    inlineClose,
+    inlineDelimiters = inlineOpen && inlineClose
+      ? /** @type {Delimiter[]} */ ([[inlineOpen, inlineClose]])
+      : /** @type {Delimiter[]} */ (["$", ["$`", "`$"]]),
+
+    blockOpen,
+    blockClose,
+    blockDelimiters = blockOpen && blockClose
+      ? /** @type {Delimiter[]} */ ([[blockOpen, blockClose]])
+      : "$$",
 
     inlineCustomElement,
     inlineRenderer = inlineCustomElement
@@ -307,17 +318,25 @@ export default function markdownItMath(
       : defaultBlockRenderer(defaultRendererOptions, md),
   } = {},
 ) {
-  const inlineMathRule = createInlineMathRule(inlineOpen, inlineClose);
-  const blockMathRule = createBlockMathRule(blockOpen, blockClose);
+  const inlineDelimitersArray = fromDelimiterOption(inlineDelimiters);
+  if (inlineDelimitersArray) {
+    const inlineMathRule = createInlineMathRule(inlineDelimitersArray);
 
-  md.inline.ruler.before("escape", "math_inline", inlineMathRule);
-  md.block.ruler.after("blockquote", "math_block", blockMathRule, {
-    alt: ["paragraph", "reference", "blockquote", "list"],
-  });
+    md.inline.ruler.before("escape", "math_inline", inlineMathRule);
 
-  md.renderer.rules.math_inline = (tokens, idx) =>
-    inlineRenderer(tokens[idx].content, tokens[idx], md);
+    md.renderer.rules.math_inline = (tokens, idx) =>
+      inlineRenderer(tokens[idx].content, tokens[idx], md);
+  }
 
-  md.renderer.rules.math_block = (tokens, idx) =>
-    `${blockRenderer(tokens[idx].content, tokens[idx], md)}\n`;
+  const blockDelitiersArray = fromDelimiterOption(blockDelimiters);
+  if (blockDelitiersArray) {
+    const blockMathRule = createBlockMathRule(blockDelitiersArray);
+
+    md.block.ruler.after("blockquote", "math_block", blockMathRule, {
+      alt: ["paragraph", "reference", "blockquote", "list"],
+    });
+
+    md.renderer.rules.math_block = (tokens, idx) =>
+      `${blockRenderer(tokens[idx].content, tokens[idx], md)}\n`;
+  }
 }

--- a/test/test.js.snapshot
+++ b/test/test.js.snapshot
@@ -1,3 +1,7 @@
+exports[`Block Math > Allows close delimiters as long as end of line matches 1`] = `
+"<math display=\\"block\\"><mrow><mi>$</mi><mi>$</mi><mi>$</mi><mn>1</mn><mo>+</mo><mn>1</mn><mi>$</mi><mi>$</mi><mi>$</mi></mrow></math>\\n"
+`;
+
 exports[`Block Math > Block math can be indented up to 3 spaces 1`] = `
 "<math display=\\"block\\"><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math>\\n"
 `;
@@ -8,6 +12,10 @@ exports[`Block Math > Block math with apparent markup 1`] = `
 
 exports[`Block Math > But 4 means a code block 1`] = `
 "<pre><code>$$\\n1+1 = 2\\n$$\\n</code></pre>\\n"
+`;
+
+exports[`Block Math > But closes on the first match on multiline 1`] = `
+"<math display=\\"block\\"><mrow><mi>$</mi><mi>$</mi><mi>$</mi><mn>1</mn><mo>+</mo><mn>1</mn><mi>$</mi></mrow></math>\\n<math display=\\"block\\"></math>\\n"
 `;
 
 exports[`Block Math > Can appear in lists 1`] = `
@@ -24,6 +32,10 @@ exports[`Block Math > Can be written in one line 1`] = `
 
 exports[`Block Math > Can span multiple lines 1`] = `
 "<math display=\\"block\\"><mrow><mo fence=\\"true\\">[</mo><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable><mo fence=\\"true\\">]</mo></mrow></math>\\n"
+`;
+
+exports[`Block Math > Matches the longest possible delimiter 1`] = `
+"<math display=\\"block\\"><mrow><mi>$</mi><mi>$</mi><mn>1</mn><mo>+</mo><mn>1</mn><mi>$</mi><mi>$</mi></mrow></math>\\n"
 `;
 
 exports[`Block Math > Multiline block math 1`] = `
@@ -46,6 +58,10 @@ exports[`Inline Math > Can be escaped 1`] = `
 "<p>Foo $1$ bar</p>\\n"
 `;
 
+exports[`Inline Math > Empty expressions are not allowed 1`] = `
+"<p>foo $$ bar</p>\\n"
+`;
+
 exports[`Inline Math > End of document is not allowed 1`] = `
 "<p>foo $1+1 = 2</p>\\n"
 `;
@@ -56,6 +72,10 @@ exports[`Inline Math > Inline math with apparent markup 1`] = `
 
 exports[`Inline Math > Multiline inline math 1`] = `
 "<p>foo <math><mn>1</mn><mo>+</mo><mn>1</mn><mspace depth=\\"1em\\" /><mo>=</mo><mn>2</mn></math> bar</p>\\n"
+`;
+
+exports[`Inline Math > Multiple maths and text 1`] = `
+"<p>foo <math><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math> bar <math><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow></math> quux</p>\\n"
 `;
 
 exports[`Inline Math > Paragraph break in inline math is not allowed 1`] = `
@@ -86,6 +106,14 @@ exports[`Inline Math > Simple inline math 1`] = `
 "<p><math><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math></p>\\n"
 `;
 
+exports[`Inline Math > Simple inline math with $\`...\`$ notation 1`] = `
+"<p><math><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math></p>\\n"
+`;
+
+exports[`Inline Math > This is an ignored expression, and a space after open, both are ignored 1`] = `
+"<p>foo $$$ bar</p>\\n"
+`;
+
 exports[`Inline Math > Whitespace around delims is not required 1`] = `
 "<p>foo<math><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math>bar</p>\\n"
 `;
@@ -98,12 +126,32 @@ exports[`Inline Math > Whitespace immediately before closing is not allowed 1`] 
 "<p>foo $1+1 = 2 $bar</p>\\n"
 `;
 
+exports[`Inline Math > dollar inside math 1`] = `
+"<p><math><mi>$</mi></math></p>\\n"
+`;
+
+exports[`Options > Depricated > inlineOpen inlineClose blockOpen blockClose 1`] = `
+"<p><math><mtext>inline</mtext></math></p>\\n<math display=\\"block\\"><mtext>block</mtext></math>\\n"
+`;
+
 exports[`Options > Different options for the default renderer 1`] = `
 "<p><math><mn>40,2</mn></math></p>\\n<math display=\\"block\\"><mn>40,2</mn></math>\\n"
 `;
 
+exports[`Options > Empty open or close dilimeters are filtered out 1`] = `
+"<p>Foo $1+1 = 2$ bar</p>\\n<p>$$\\n1+1 = 2\\n$$</p>\\n"
+`;
+
 exports[`Options > LaTeX style delims 1`] = `
 "<p>Foo <math><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math> bar</p>\\n<math display=\\"block\\"><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math>\\n"
+`;
+
+exports[`Options > No delimiters turns off rules 1`] = `
+"<p>Foo $1+1 = 2$ bar</p>\\n<p>$$\\n1+1 = 2\\n$$</p>\\n"
+`;
+
+exports[`Options > Space dollar delims 1`] = `
+"<p>Foo <math><mrow><mn>1</mn><mo>+</mo><mn>1</mn></mrow><mo>=</mo><mn>2</mn></math> bar</p>\\n"
 `;
 
 exports[`Options > Thick dollar delims 1`] = `


### PR DESCRIPTION
Add a new option for `inlineDelimiters` and `blockDelimiters` which accepts an array of open close pairs. This allows authors to have multiple delimiter pairs which matches many flavors of Markdown, inlcuding GFM.

Breaking change: Empty math expressions are no longer renderer.

- Depricates: `inlineOpen`, and `inlineClose` in favor of `inlineDelimiters`.
- Depricates: `blockOpen`, and `blockClose` in favor of `blockDelimiters`.