### PR TITLE
Fix generated declaration types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Markdown-it plugin to include math in your document",
   "main": "index.js",
-  "types": "types/index.js",
+  "types": "types/index.d.ts",
   "exports": {
     ".": {
       "types": "./types/index.d.ts",

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,8 @@
 /**
  * @typedef {string | [string, string]} Delimiter
  * @typedef {string | [tag: string, attrs?: Record<string, string>]} CustomElementOption
+ * @typedef {import("markdown-it/dist/index.cjs.js")} MarkdownIt
+ * @typedef {import("markdown-it/lib/token.mjs").default} Token
  * @callback Renderer
  * @param {string} src - The source content
  * @param {Token} token - The parsed markdown-it token

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("mathup").Options} MathupOptions
- * @typedef {import("markdown-it").default} MarkdownIt
+ * @typedef {import("markdown-it/dist/index.cjs.js")} MarkdownIt
  * @typedef {import("markdown-it/lib/token.mjs").default} Token
  *
  * @typedef {import("./options.js").CustomElementOption} CustomElementOption

--- a/src/renderers.js
+++ b/src/renderers.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {import("mathup").Options} MathupOptions
- * @typedef {import("markdown-it").default} MarkdownIt
+ * @typedef {import("markdown-it/dist/index.cjs.js")} MarkdownIt
  * @typedef {import("./options.js").CustomElementOption} CustomElementOption
  */
 


### PR DESCRIPTION
## Summary
- point the top-level package types field at the generated declaration file
- add missing markdown-it and Token typedefs used by the generated Renderer type
- avoid emitting markdown-it .default references that fail for consumers using @types/markdown-it

## Verification
- npm run check
- npm test
- npx eslint src/options.js src/plugin.js src/renderers.js
- npm pack, install the local tarball into a clean TypeScript project, and run npx tsc --noEmit

The current published package fails the same consumer TypeScript test with missing Token/MarkdownIt names and the markdown-it .default type reference.