### PR TITLE
Make temml and mathup optional dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "markdown-it-math",
       "version": "5.2.1",
       "license": "MIT",
+      "dependencies": {
+        "temml": "0.11"
+      },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@types/markdown-it": "^14.1.2",
@@ -21,17 +24,9 @@
         "prettier": "3.5.3",
         "typescript": "^5.8.2"
       },
-      "peerDependencies": {
+      "optionalDependencies": {
         "mathup": "^1.0.0",
-        "temml": "^0.11.0"
-      },
-      "peerDependenciesMeta": {
-        "mathup": {
-          "optional": true
-        },
-        "temml": {
-          "optional": true
-        }
+        "temml": "^0.11.11"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -1133,7 +1128,6 @@
       "integrity": "sha512-EZTpzgXc/e2EmFMBLcxzr0WZyfdy59Z5HjFAed6iQEcfwtpEAY2/bKK436UCUHlzKaiinG0D8qjWQhwsO8SbkQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "mathup": "bin/mathup.js"
       }
@@ -1450,12 +1444,11 @@
       }
     },
     "node_modules/temml": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/temml/-/temml-0.11.2.tgz",
-      "integrity": "sha512-7YkDcDYE5UXV6yOGYgcT2A0J+IeXye2gXg77eH8WxLOcVssGMxPSxkh6GkyZ5owLM4C3u/d5oG/2gZrlQ+mAew==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.11.11.tgz",
+      "integrity": "sha512-Z/Ihgwad+ges0ez6+KmKWZ3o4BYbP6aZ/cU94cVtN+DwxwqxjHgcF4Z6cb9jLkKN+aU7uni165HsIxLHs5/TqA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18.13.0"
       }

--- a/package.json
+++ b/package.json
@@ -64,16 +64,8 @@
     "prettier": "3.5.3",
     "typescript": "^5.8.2"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "mathup": "^1.0.0",
-    "temml": "^0.11.0"
-  },
-  "peerDependenciesMeta": {
-    "mathup": {
-      "optional": true
-    },
-    "temml": {
-      "optional": true
-    }
+    "temml": "^0.11.11"
   }
 }


### PR DESCRIPTION
As opposed to optional peer dependencies. `npm ci` no longer installed them by default.