### PR TITLE
Remove deprecated defaultRendererOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,21 +8,11 @@ const mathup = await import("mathup").then(
 /**
  * @typedef {import("./src/plugin.js").PluginOptions} PluginOptions
  * @typedef {import("mathup").Options} MathupOptions
- * @typedef {object} ExtraOptions
- * @property {MathupOptions} [defaultRendererOptions] - DEPRICATED: use mathupOptions.
- * @property {MathupOptions} [mathupOptions] - Options passed into the mathup default renderer.
- * @typedef {PluginOptions & ExtraOptions} MarkdownItMathOptions
+ * @typedef {PluginOptions & { mathupOptions?: MathupOptions }} MarkdownItMathOptions
  */
 
 /** @type {import("markdown-it").PluginWithOptions<MarkdownItMathOptions>} */
-export default function markdownItMath(
-  md,
-  {
-    defaultRendererOptions,
-    mathupOptions = defaultRendererOptions,
-    ...options
-  } = {},
-) {
+export default function markdownItMath(md, { mathupOptions, ...options } = {}) {
   if (!mathup) {
     return plugin(md, options);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "markdown-it-math",
       "version": "5.2.1",
       "license": "MIT",
-      "dependencies": {
-        "temml": "0.11"
-      },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@types/markdown-it": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "node --test --experimental-test-coverage",
     "test:coverage-badge": "mkdir -p coverage && node --test --experimental-test-coverage --test-reporter ./test/reporters/coverage-badge-reporter.js --test-reporter-destination coverage/badge.svg",
     "test:watch": "node --test --watch",
-    "types": "tsc index.js no-default-renderer.js temml.js --allowJS --declaration --declarationMap --emitDeclarationOnly --esModuleInterop --outDir types"
+    "types": "tsc --declaration --declarationMap --emitDeclarationOnly --outDir types"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -561,27 +561,6 @@ $$`;
 
       assert.equal(mdDepricated.render(src), mdRecommended.render(src));
     });
-
-    test("defaultRendererOptions", () => {
-      const mdDepricated = markdownIt().use(markdownItMath, {
-        defaultRendererOptions: {
-          decimalMark: ",",
-        },
-      });
-
-      const mdRecommended = markdownIt().use(markdownItMath, {
-        mathupOptions: {
-          decimalMark: ",",
-        },
-      });
-
-      const src = `$40,2$
-$$
-40,2
-$$`;
-
-      assert.equal(mdDepricated.render(src), mdRecommended.render(src));
-    });
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "esnext",
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "allowSyntheticDefaultImports": true,
     "strict": true,
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
Also fixed a regression in typescript not able to create d.ts of mathup options.

(see https://github.com/microsoft/TypeScript/issues/42873).