### PR TITLE
Fix renderer callback declaration types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Markdown-it plugin to include math in your document",
   "main": "index.js",
-  "types": "types/index.js",
+  "types": "types/index.d.ts",
   "exports": {
     ".": {
       "types": "./types/index.d.ts",

--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,6 @@
 /**
+ * @typedef {import("markdown-it").default} MarkdownIt
+ * @typedef {import("markdown-it/lib/token.mjs").default} Token
  * @typedef {string | [string, string]} Delimiter
  * @typedef {string | [tag: string, attrs?: Record<string, string>]} CustomElementOption
  * @callback Renderer


### PR DESCRIPTION
## Summary
- import the `MarkdownIt` and `Token` typedefs used by the exported `Renderer` callback type
- point the package-level `types` field at the emitted `types/index.d.ts` file

## Verification
- `npm run types`
- `npm run check`
- `npm test`
- packed the package locally and verified a strict TypeScript consumer can import `markdown-it-math`

`npm run lint` currently reports repository-wide CRLF/prettier line-ending errors in this Windows checkout, including untouched files.